### PR TITLE
Update overview

### DIFF
--- a/overview/configuration.md
+++ b/overview/configuration.md
@@ -50,7 +50,7 @@ Of course you can try to start the service directly as this will be done anyway.
 The configuration file contains a lot of different options that are not explained in this section, the best way to get familiar with them is using the KrakenDesigner.
 
 ## Configuration file example
-This is simplified example of a configuration file:
+This is a simplified example of a configuration file:
 
 	{
 	    "version": 2,

--- a/overview/installing.md
+++ b/overview/installing.md
@@ -10,22 +10,32 @@ menu:
 title: Installing KrakenD
 weight: 20
 ---
+KrakenD is a **single binary file** that does not require any external libraries to work. To install KrakenD choose your operative system in the downloads section or use the Docker image.
 
-# Linux and Mac OS X - from tar.gz
-KrakenD is self-contained and does not require to have additional libraries in the system, so all you need
-to do is run the binary. To install KrakenD go through the following steps:
 
-1. Ensure the binary you have downloaded matches your architecture (check the [download](/download) section)
-2. [Generate a `krakend.json`](http://designer.krakend.io/) configuration file using the [designer](http://designer.krakend.io/)
-3. Start the KrakenD: `./krakend run --config krakend.json`
+<a href="/download" class="btn btn-primary">Download KrakenD</a>
+and
+<a href="http://designer.krakend.io" class="btn btn-primary">Generate the configuration file</a>
 
-If you want this for production make sure to move `krakend` and `krakend.json` to a directory of your
-choice, like `/etc/krakend/` or `/usr/local/krakend`.
 
-If you attempt to run a binary in a platform it was not built for you might see a strange error. For
-instance running krakend for Linux AMD64 in a Mac might show the following message:
+**Just exploring?**
 
-    sh: exec format error: /Downloads/krakend/krakend_{{% version %}}_amd64
+Use the [KrakenD Playground](https://github.com/devopsfaith/krakend-playground) if you want to play with KrakenD without configuring it. The Playground comes with several flavors of KrakenD and a mock API. Everything is ready to start playing, just do a `docker-compose up`!
+
+# Docker
+If you are already familiar with Docker, the easiest way to get started is by pulling the [KrakenD image](https://hub.docker.com/r/devopsfaith/krakend/) from the Docker Hub:
+
+    docker pull devopsfaith/krakend
+    docker run -p 8080:8080 -v $PWD:/etc/krakend/ devopsfaith/krakend run --config /etc/krakend/krakend.json
+
+Make sure you have a `krakend.json` in the current directory with your endpoint definition. You can [generate it here](http://designer.krakend.io/)
+
+# Mac OS X
+The [Homebrew](https://brew.sh/) formula will download the source code, build the formula and link the binary for you.
+
+    brew install krakend
+
+# Linux
 
 ## CentOS and Redhat
 The installation process requires following these steps:
@@ -67,49 +77,9 @@ Bottom line:
 
 Current KrakenD version will run at least in Debian 8, Debian 9 and Ubuntu 16.x
 
-# Docker
-If you are already familiar with Docker the most convenient way to get started is by pulling the [KrakenD image](https://hub.docker.com/r/devopsfaith/krakend/) from Docker Hub:
-
-    docker pull devopsfaith/krakend
-    docker run -p 8080:8080 -v $PWD:/etc/krakend/ devopsfaith/krakend run --config /etc/krakend/krakend.json
-
-Make sure you have a `krakend.json` in the current directory with your endpoint definition. You can [generate it here](http://designer.krakend.io/)
+## Generic (via `tar.gz`)
+You can also [download](/download) the `tar.gz` and decompress it anywhere. Instructions to check the SHA and PGP signature [here](/docs/overview/verifying-packages).
 
 
-
-# PGP
-
-We will check the detached signature [PGP](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.asc) against our package [KrakenD](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz).
-
-    $ gpg --verify krakend_{{% version %}}_amd64.tar.gz.asc krakend_{{% version %}}_amd64.tar.gz
-    gpg: Signature made vie 02 dic 2016 19:07:49 CET using RSA key ID AB39BEA1
-    gpg: Can't check signature: public key not found
-
-We don't have the packager public key (AB39BEA1) in our system. You need to retrieve the public key from a key server.
-
-    $ gpg --keyserver keyserver.ubuntu.com --recv-key AB39BEA1
-    gpg: requesting key AB39BEA1 from hkp server keyserver.ubuntu.com
-    gpg: trustdb created
-    gpg: key AB39BEA1: public key "Daniel Ortiz <dortiz@devops.faith>" imported
-    gpg: Total number processed: 1
-    gpg:							 imported: 1	(RSA: 1)
-
-Now you can verify the signature of the package:
-
-    $ gpg --verify krakend_{{% version %}}_amd64.tar.gz.asc krakend_{{% version %}}_amd64.tar.gz
-    gpg: Signature made jue 01 dic 2016 14:00:38 CET using RSA key ID AB39BEA1
-    gpg: Good signature from "Daniel Ortiz <dortiz@devops.faith>"
-    gpg: WARNING: This key is not certified with a trusted signature!
-    gpg:					There is no indication that the signature belongs to the owner.
-    Primary key fingerprint: EF9B 4CED 47D0 ECC9 69F8  3B4A 7377 C22B AB39 BEA1
-
-
-# SHA256
-
-To make sure the binary downloaded matches our SHA256 ensure the next 2 commands produce the same [SHA](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.sha256) output.
-
-    # Your downloaded file
-	$ shasum -a 256 -b krakend_{{% version %}}_amd64.tar.gz
-    # Our SHA256
-    $ curl http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.sha256
-
+# Build KrakenD yourself
+As KrakenD is open source you can opt for [building the binary](https://github.com/devopsfaith/krakend-ce). The binary you will produce is the same you can get in our download page, only that compiling it yourself always feels good!

--- a/overview/krakend-vs-krakend-ce.md
+++ b/overview/krakend-vs-krakend-ce.md
@@ -1,0 +1,38 @@
+---
+lastmod: 2018-06-23
+date: 2018-06-23
+linktitle: KrakenD vs KrakenD-CE
+description: What is the difference between KrakenD and KrakenD-CE?
+notoc: true
+menu:
+  main:
+    parent: getting started
+title: KrakenD vs KrakenD-CE
+weight: 100
+---
+If you had a quick look at our git repositories you might be confused at first, as we have a repository named `krakend` and another one named `krakend-ce`.
+
+# What is the difference between KrakenD and KrakenD-CE? and KrakenD Enterprise?
+**TL;DR;**
+
+- KrakenD is a framework
+- KrakenD-CE is a ready to use API Gateway
+- KrakenD Enterprise is professional services to businesses
+
+## KrakenD framework
+KrakenD ([repo](https://github.com/devopsfaith/krakend)) is an open-source project created by [@devopsfaith](https://twitter.com/devopsfaith) to accelerate the creation of API Gateways. The KrakenD framework provides several components for assembling your own API Gateway and can be used in its entirety or just importing it as Go libraries to take only some of the functionality it brings.
+
+Unlike the rest of API Gateways in the space, KrakenD framework aims to bring together Go enthusiasts and professionals to collaborate together towards building API Gateways. KrakenD is very modular and lets you replace the components or add new ones (middlewares).
+
+KrakenD focuses on building the core framework and functionality a pure API gateway needs and it keeps it clean and extensible so you can create your own custom gateway without trouble.
+
+
+## KrakenD Community Edition
+`KrakenD-CE` ([repo](https://github.com/devopsfaith/krakend-ce)) is a ready to use API gateway. This is our interpretation of what the community will need, just one answer of the thousands of combinations an API Gateway might need. The KrakenD-CE uses the KrakenD framework in its core and extends its functionality by adding in the final binary some of the several [middleware contributions](https://github.com/devopsfaith/krakend-contrib) we thought an API Gateway should have.
+
+KrakenD-CE adds to the KrakenD framework interesting functionality like logging, service discovery, developer tools, metrics, circuit breaker, rate limiting, oauth, security and other interesting stuff.
+
+The good news, is that we always refer to both things as "KrakenD" :)
+
+## KrakenD Enterprise
+There is no Enterprise software. KrakenD(-CE) is the same product for paying customers or the community. The KrakenD Enterprise subscription is a series of services in consultancy, development and support around KrakenD.

--- a/overview/verifying-packages.md
+++ b/overview/verifying-packages.md
@@ -1,0 +1,43 @@
+---
+lastmod: 2016-06-23
+date: 2016-07-01
+title: Verifying packages (PGP and SHA256)
+notoc: true
+---
+How to make sure what you are downloading is legit.
+
+# PGP
+We will check the detached signature [PGP](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.asc) against our package [KrakenD](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz).
+
+    $ gpg --verify krakend_{{% version %}}_amd64.tar.gz.asc krakend_{{% version %}}_amd64.tar.gz
+    gpg: Signature made vie 02 dic 2016 19:07:49 CET using RSA key ID AB39BEA1
+    gpg: Can't check signature: public key not found
+
+We don't have the packager public key (AB39BEA1) in our system. You need to retrieve the public key from a key server.
+
+    $ gpg --keyserver keyserver.ubuntu.com --recv-key AB39BEA1
+    gpg: requesting key AB39BEA1 from hkp server keyserver.ubuntu.com
+    gpg: trustdb created
+    gpg: key AB39BEA1: public key "Daniel Ortiz <dortiz@devops.faith>" imported
+    gpg: Total number processed: 1
+    gpg:							 imported: 1	(RSA: 1)
+
+Now you can verify the signature of the package:
+
+    $ gpg --verify krakend_{{% version %}}_amd64.tar.gz.asc krakend_{{% version %}}_amd64.tar.gz
+    gpg: Signature made jue 01 dic 2016 14:00:38 CET using RSA key ID AB39BEA1
+    gpg: Good signature from "Daniel Ortiz <dortiz@devops.faith>"
+    gpg: WARNING: This key is not certified with a trusted signature!
+    gpg:					There is no indication that the signature belongs to the owner.
+    Primary key fingerprint: EF9B 4CED 47D0 ECC9 69F8  3B4A 7377 C22B AB39 BEA1
+
+
+# SHA256
+
+To make sure the binary downloaded matches our SHA256 ensure the next 2 commands produce the same [SHA](http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.sha256) output.
+
+    # Your downloaded file
+	$ shasum -a 256 -b krakend_{{% version %}}_amd64.tar.gz
+    # Our SHA256
+    $ curl http://repo.krakend.io/bin/krakend_{{% version %}}_amd64.tar.gz.sha256
+


### PR DESCRIPTION
- Added page with differences between krakenD and KrakenD-CE
- Updated installation instructions as we do not longer provide tar.gz for mac, now via homebrew