### PR TITLE
Better querystring documentation and /__debug endpoint

### DIFF
--- a/endpoints/debug-endpoint.md
+++ b/endpoints/debug-endpoint.md
@@ -1,0 +1,108 @@
+---
+lastmod: 2018-11-27
+date: 2018-11-27
+linktitle: Debug endpoint
+menu:
+  documentation:
+    parent: endpoints
+title: The `/__debug` endpoint
+weight: 35
+---
+The `/__debug` endpoint is available when you start the server with the `-d` flag.
+
+The endpoint can be used as a fake backend to see its activity in the log. When developing, add KrakenD itself as a backend using the `/__debug/` endpoint so you can see exactly what headers and query string parameters your backends are receiving.
+
+The debug endpoint might save you a lot of trouble, as your application might not work when certain headers or parameters are not present, and you might be relying in what your client is sending, and not in what the gateway is sending.
+
+For instance, your client might be sending a `Content-Type` header, but unless this header is recognized by the gateway (added in `headers_to_pass`), it is not going to reach the backend. Seeing the exact headers and parameters in the log clear all the doubts and you can reproduce the call and conditions easily.
+
+# Debug endpoint configuration example
+The following configuration demonstrates how to test what headers and query string parameters are sent and received by the backends.
+
+We are going to test the following endpoints:
+
+- `/default-behavior`: No client headers, query string or cookies are forwarded.
+- `/known-params`: Forwards known parameters and headers
+    - Recognizes `a` and `b` as query string
+    - Recognizes `User-Agent` as forwarded header
+
+To test it right now, save the content of this file in a `krakend-test.json` and start the server with the `-d` flag:
+
+    {
+        "version": 2,
+        "port": 8080,
+        "endpoints": [
+            {
+            "endpoint": "/default-behavior",
+            "method": "GET",
+            "backend": [
+                {
+                "url_pattern": "/__debug/all",
+                "host": [ "http://127.0.0.1:8080" ]
+                }
+            ]
+            },
+            {
+            "endpoint": "/known-params",
+            "method": "GET",
+            "querystring_params": [
+                "a",
+                "b"
+            ],
+            "headers_to_pass": [
+                "User-Agent",
+                "Accept"
+            ],
+            "backend": [
+                {
+                "url_pattern": "/__debug/some",
+                "host": [ "http://127.0.0.1:8080" ]
+                }
+            ]
+            }
+        ]
+    }
+
+Start the server:
+
+    krakend run -d -c krakend-test.json
+
+
+Now we can test that the endpoints behave as expected
+
+**Default behavior:**
+
+    curl -i 'http://localhost:8080/default-behavior?a=1&b=2&c=3'
+
+The `curl` command automatically sends the `Accept` and `User-Agent` headers. And then in the KrakenD log we can see that `a`, `b`, and `c` are not forwarded, neither its headers.
+
+{{< highlight go "hl_lines=5 8" >}}
+DEBUG: Method: GET
+DEBUG: URL: /__debug/all
+DEBUG: Query: map[]
+DEBUG: Params: [{param /all}]
+DEBUG: Headers: map[User-Agent:[KrakenD Version 0.7.0] X-Forwarded-For:[::1] Accept-Encoding:[gzip]]
+DEBUG: Body:
+[GIN] 2018/11/27 - 22:32:44 | 200 |     118.543µs |             ::1 | GET      /__debug/all
+[GIN] 2018/11/27 - 22:32:44 | 200 |     565.971µs |             ::1 | GET      /default-behavior?a=1&b=2&c=3
+{{< /highlight >}}
+
+Now let's repeat the same with the known parameters:
+
+    curl -i 'http://localhost:8080/known-params?a=1&b=2&c=3'
+
+And now in the KrakenD log now we can see that the `User-Agent` and `Accept` are present:
+
+{{< highlight go "hl_lines=5 8" >}}
+DEBUG: Method: GET
+ DEBUG: URL: /__debug/some?a=1&b=2
+ DEBUG: Query: map[a:[1] b:[2]]
+ DEBUG: Params: [{param /some}]
+ DEBUG: Headers: map[User-Agent:[curl/7.54.0] Accept:[*/*] X-Forwarded-For:[::1] Accept-Encoding:[gzip]]
+ DEBUG: Body:
+[GIN] 2018/11/27 - 22:33:23 | 200 |     122.507µs |             ::1 | GET      /__debug/some?a=1&b=2
+[GIN] 2018/11/27 - 22:33:23 | 200 |     542.483µs |             ::1 | GET      /known-params?a=1&b=2&c=3
+{{< /highlight >}}
+
+
+

--- a/endpoints/debug-endpoint.md
+++ b/endpoints/debug-endpoint.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2018-11-27
+lastmod: 2018-11-28
 date: 2018-11-27
 linktitle: Debug endpoint
 menu:
@@ -12,16 +12,16 @@ The `/__debug` endpoint is available when you start the server with the `-d` fla
 
 The endpoint can be used as a fake backend to see its activity in the log. When developing, add KrakenD itself as a backend using the `/__debug/` endpoint so you can see exactly what headers and query string parameters your backends are receiving.
 
-The debug endpoint might save you a lot of trouble, as your application might not work when certain headers or parameters are not present, and you might be relying in what your client is sending, and not in what the gateway is sending.
+The debug endpoint might save you a lot of trouble, as your application might not work when certain headers or parameters are not present, and you might be relying upon what your client is sending, and not in what the gateway is sending.
 
-For instance, your client might be sending a `Content-Type` header, but unless this header is recognized by the gateway (added in `headers_to_pass`), it is not going to reach the backend. Seeing the exact headers and parameters in the log clear all the doubts and you can reproduce the call and conditions easily.
+For instance, your client might be sending a `Content-Type` header, but unless this header pear is recognized by the gateway (added in `headers_to_pass`), it is not going to reach the backend. Seeing the specific headers and parameters in the log clears all the doubts, and you can reproduce the call and conditions easily.
 
 # Debug endpoint configuration example
 The following configuration demonstrates how to test what headers and query string parameters are sent and received by the backends.
 
 We are going to test the following endpoints:
 
-- `/default-behavior`: No client headers, query string or cookies are forwarded.
+- `/default-behavior`: No client headers, query string or cookies forwarded.
 - `/known-params`: Forwards known parameters and headers
     - Recognizes `a` and `b` as query string
     - Recognizes `User-Agent` as forwarded header
@@ -74,7 +74,7 @@ Now we can test that the endpoints behave as expected
 
     curl -i 'http://localhost:8080/default-behavior?a=1&b=2&c=3'
 
-The `curl` command automatically sends the `Accept` and `User-Agent` headers. And then in the KrakenD log we can see that `a`, `b`, and `c` are not forwarded, neither its headers.
+In the KrakenD log, we can see that `a`, `b`, and `c` do not appear in the backend call, neither its headers (**note**: the `curl` command automatically sends the `Accept` and `User-Agent` headers)
 
 {{< highlight go "hl_lines=5 8" >}}
 DEBUG: Method: GET
@@ -87,11 +87,11 @@ DEBUG: Body:
 [GIN] 2018/11/27 - 22:32:44 | 200 |     565.971µs |             ::1 | GET      /default-behavior?a=1&b=2&c=3
 {{< /highlight >}}
 
-Now let's repeat the same with the known parameters:
+Now let's repeat the same request but to the known parameters endpoint:
 
     curl -i 'http://localhost:8080/known-params?a=1&b=2&c=3'
 
-And now in the KrakenD log now we can see that the `User-Agent` and `Accept` are present:
+In the KrakenD log we can see now that the `User-Agent` and `Accept` are present (as they are implicitly sent by curl):
 
 {{< highlight go "hl_lines=5 8" >}}
 DEBUG: Method: GET
@@ -103,6 +103,3 @@ DEBUG: Method: GET
 [GIN] 2018/11/27 - 22:33:23 | 200 |     122.507µs |             ::1 | GET      /__debug/some?a=1&b=2
 [GIN] 2018/11/27 - 22:33:23 | 200 |     542.483µs |             ::1 | GET      /known-params?a=1&b=2&c=3
 {{< /highlight >}}
-
-
-

--- a/endpoints/debug-endpoint.md
+++ b/endpoints/debug-endpoint.md
@@ -14,17 +14,17 @@ The endpoint can be used as a fake backend to see its activity in the log. When 
 
 The debug endpoint might save you a lot of trouble, as your application might not work when certain headers or parameters are not present, and you might be relying upon what your client is sending, and not in what the gateway is sending.
 
-For instance, your client might be sending a `Content-Type` header, but unless this header pear is recognized by the gateway (added in `headers_to_pass`), it is not going to reach the backend. Seeing the specific headers and parameters in the log clears all the doubts, and you can reproduce the call and conditions easily.
+For instance, your client might be sending a `Content-Type` header, but unless this header is recognized by the gateway (is added in `headers_to_pass`), it is not going to reach the backend. Seeing the specific headers and parameters in the log clears all the doubts, and you can reproduce the call and conditions easily.
 
 # Debug endpoint configuration example
-The following configuration demonstrates how to test what headers and query string parameters are sent and received by the backends.
+The following configuration demonstrates how to test what headers and query string parameters are sent and received by the backends by using the `/__debug` endpoint.
 
 We are going to test the following endpoints:
 
 - `/default-behavior`: No client headers, query string or cookies forwarded.
 - `/known-params`: Forwards known parameters and headers
     - Recognizes `a` and `b` as query string
-    - Recognizes `User-Agent` as forwarded header
+    - Recognizes `User-Agent` and `Accept` as forwarded headers
 
 To test it right now, save the content of this file in a `krakend-test.json` and start the server with the `-d` flag:
 
@@ -68,26 +68,26 @@ Start the server:
     krakend run -d -c krakend-test.json
 
 
-Now we can test that the endpoints behave as expected
+Now we can test that the endpoints behave as expected:
 
 **Default behavior:**
 
     curl -i 'http://localhost:8080/default-behavior?a=1&b=2&c=3'
 
-In the KrakenD log, we can see that `a`, `b`, and `c` do not appear in the backend call, neither its headers (**note**: the `curl` command automatically sends the `Accept` and `User-Agent` headers)
+In the KrakenD log, we can see that `a`, `b`, and `c` do not appear in the backend call, neither its headers. The `curl` command automatically sends the `Accept` and `User-Agent` headers and as you can see below the user agent is the gateway itself:
 
 {{< highlight go "hl_lines=5 8" >}}
 DEBUG: Method: GET
 DEBUG: URL: /__debug/all
 DEBUG: Query: map[]
 DEBUG: Params: [{param /all}]
-DEBUG: Headers: map[User-Agent:[KrakenD Version 0.7.0] X-Forwarded-For:[::1] Accept-Encoding:[gzip]]
+DEBUG: Headers: map[User-Agent:[KrakenD Version {{% version %}}] X-Forwarded-For:[::1] Accept-Encoding:[gzip]]
 DEBUG: Body:
 [GIN] 2018/11/27 - 22:32:44 | 200 |     118.543µs |             ::1 | GET      /__debug/all
 [GIN] 2018/11/27 - 22:32:44 | 200 |     565.971µs |             ::1 | GET      /default-behavior?a=1&b=2&c=3
 {{< /highlight >}}
 
-Now let's repeat the same request but to the known parameters endpoint:
+Now let's repeat the same request but to the `/known-params` endpoint:
 
     curl -i 'http://localhost:8080/known-params?a=1&b=2&c=3'
 

--- a/endpoints/parameter-forwarding.md
+++ b/endpoints/parameter-forwarding.md
@@ -1,9 +1,8 @@
 ---
-lastmod: 2018-09-27
+lastmod: 2018-11-27
 date: 2018-07-20
 aliases:
 - /docs/features/parameter-forwarding/
-toc: true
 linktitle:  Parameter forwarding
 title: Parameter forwarding
 weight: 30
@@ -11,116 +10,172 @@ menu:
   documentation:
     parent: endpoints
 ---
-KrakenD always **alleviates backends** avoiding to pollute them with everything coming from the clients. By default, **no parameters sent by clients are forwarded to backends** and if needed they will require an explicit declaration in the configuration file.
+KrakenD is an API Gateway, and when it comes to forward query strings, cookies, and headers, it **does not behave like a regular proxy** by forwarding parameters to the backend.
 
-The parameter forwarding refers to:
+The **default policy** for data forwarding works as follows:
 
-- [Query string](#query-string-forwarding)
-- [Headers](#headers-forwarding)
-- [Cookies](#cookies-forwarding)
+- No [query string](#query-string-forwarding) parameters are forwarded to the backend
+- No [headers](#headers-forwarding) are forwarded
+- No [cookies](#cookies-forwarding) are forwarded
+
+You can change this behavior according to your needs, and define which elements are allowed to pass.
+
+However, if you want a specific endpoint to act just like a regular proxy without doing any operations use the `no-op` option on its encoding options. When using `no-op`, the gateway can't probe the content whatsoever. The request goes from the client to the backend "as is".
 
 # Query string forwarding
-Use `querystring_params`
+KrakenD **sends all query string parameters to the backend by default**. Meaning that if an endpoint `/foo` receives the query string `/foo?a=1&b=2` all its declared backends are going to receive `a` and `b`.
 
-In order to receive the query strings sent by clients in your backends, you will need to declare in the `querystring_params` the list of recognized parameters. When this list is set, any matching parameters are included in the backend call **when present**.
+Nevertheless, it's recommended to add the property list `querystring_params` in the `endpoint` configuration to declare the allowed parameters and avoid polluting backends. When this list exists in the configuration, the forwarding policy behaves like a whitelist: all matching parameters declared in the `querystring_params` list are forwarded to the backend, and the rest dropped.
 
-For instance, let's forward`?a=1&b=2` to the backends:
+For instance, let's forward `?a=1&b=2` only to the backends:
 
-	{
-	  "version": 2,
-	  "endpoints": [
-	    {
-	      "endpoint": "/v1/foo",
-	      "method": "GET",
-	      "querystring_params": [
-	        "a",
-	        "b"
-	      ],
-	      "backend": [
-	        {
-	          "url_pattern": "/catalog",
-	          "sd": "static",
-	          "host": [
-	            "http://some.api.com:9000"
-	          ]
-	        }
-	      ]
-	    }
-	  ]
-	}
+    {
+      "version": 2,
+      "endpoints": [
+        {
+          "endpoint": "/v1/foo",
+          "method": "GET",
+          "querystring_params": [
+            "a",
+            "b"
+          ],
+          "backend": [
+            {
+              "url_pattern": "/catalog",
+              "sd": "static",
+              "host": [
+                "http://some.api.com:9000"
+              ]
+            }
+          ]
+        }
+      ]
+    }
 
-With this configuration, given a request like `http://krakend:8080/v1/foo?a=1&b=2&c=3` the backend will receive `a` and `b` but `c` will be missing. But also, a request like `http://krakend:8080/v1/foo?a=1` the backend will receive `a` but `b` will be missing.
+With this configuration, given a request like `http://krakend:8080/v1/foo?a=1&b=2&evil=here`, the backend receives `a` and `b`, but `evil` is missing.
+
+Also, if a request like `http://krakend:8080/v1/foo?a=1` is skipping an allowed parameter like `b`, this parameter is missing in the backend as well.
+
+## Mixing endpoint {variables} and query string parameters
+The `{variables}` used in the endpoints definition can be injected in the backends as part of the query string parameters as well. These variables combine with any actual query string parameters in the endpoint. For instance:
+
+    ...
+    {
+            "endpoint": "/v3/{channel}/foo",
+            "backend": [
+                    {
+                            "host": ["http://backend"],
+                            "url_pattern": "/foo?channel={channel}"
+                    }
+            ]
+    }
+
+{{% note title="Important note" %}}
+Injecting variables in the backend as a query string enables the forwarding of all client query string parameters, unless the `querystring_params` is set.
+{{% /note %}}
+
+With the configuration above a request to the KrakenD endpoint such as `http://krakend/v3/iOS/foo?limit=10&evil=here` makes a call to the backend with the following query string parameters:
+
+    /foo?channel=iOS&limit=10&evil=here
+
+The same call using `querystring_params` produces the equivalent behavior, only that unexpected parameters drop:
+
+    {
+            "endpoint": "/v3/{channel}/foo",
+            "querystring_params": [
+                    "page",
+                    "limit"
+            ],
+            "backend": [
+                    {
+                            "host": ["http://backend"],
+                            "url_pattern": "/foo?channel={channel}"
+                    }
+            ]
+    }
+
+And the backend receives:
+
+    /foo?channel=iOS&limit=10
+
+No `evil` here! So, remember to set always the `querystring_params` if you intend to inject variables as parameters.
+
+Read the [`/__debug/` endpoint](/endpoints/debug-endpoint) to understand how to test query string parameters.
 
 # Headers forwarding
-Use `headers_to_pass`
+KrakenD **does not send client headers to the backend by default**.  Use `headers_to_pass`.
 
 Declare the list of headers sent by the client that you want to let pass to the backend with the `headers_to_pass` option.
 
-A client request from a browser or a mobile client usually contains a lot of headers, including cookies. Typical examples of the kind of headers that are usually received from clients are `Host`, `Connection`, `Cache-Control`, `Cookie`... and a long long etcetera. The backend usually does not need any of this to return the content.
+A client request from a browser or a mobile client usually contains a lot of headers, including cookies. Typical examples of the variety of headers that clients send are `Host`, `Connection`, `Cache-Control`, `Cookie`... and a long, long etcetera. The backend usually does not need any of this to return the content.
 
-KrakenD will pass only the essential headers to the backends, for instance:
+KrakenD passes only these essential headers to the backends:
 
-	Accept-Encoding: gzip
+    Accept-Encoding: gzip
     Host: localhost:8080
     User-Agent: KrakenD Version {{% version %}}
     X-Forwarded-For: ::1
 
- When you use the `headers_to_pass` take into account that any of these headers will be replaced with the ones you declare.
+ When you use the `headers_to_pass`, take into account that any of these headers are replaced with the ones you declare.
 
  An example to pass the `User-Agent` to the backend:
 
-	{
-	  "version": 2,
-	  "endpoints": [
-	    {
-	      "endpoint": "/v1/foo",
-	      "method": "GET",
-	      "headers_to_pass": [
-        	"User-Agent"
-      	  ],
-	      "backend": [
-	        {
-	          "url_pattern": "/catalog",
-	          "sd": "static",
-	          "host": [
-	            "http://some.api.com:9000"
-	          ]
-	        }
-	      ]
-	    }
-	  ]
-	}
+    {
+      "version": 2,
+      "endpoints": [
+        {
+          "endpoint": "/v1/foo",
+          "method": "GET",
+          "headers_to_pass": [
+            "User-Agent"
+            ],
+          "backend": [
+            {
+              "url_pattern": "/catalog",
+              "sd": "static",
+              "host": [
+                "http://some.api.com:9000"
+              ]
+            }
+          ]
+        }
+      ]
+    }
 
-This setting will change the headers received by the backend to:
+This setting changes the headers received by the backend to:
 
-	Accept-Encoding: gzip
+    Accept-Encoding: gzip
     Host: localhost:8080
     User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36
     X-Forwarded-For: ::1
 
+Read the [`/__debug/` endpoint](/endpoints/debug-endpoint) to understand how to test headers.
+
 # Cookies forwarding
-A cookie is just some content passing inside the `Cookie` header. If you want cookies to reach your backend, add the `Cookie` header under `headers_to_pass`, just as you would do with any other header. With this, **all your cookies** will be sent to all backends inside the endpoint. Use this option wisely!
+A cookie is just some content passing inside the `Cookie` header. If you want cookies to reach your backend, add the `Cookie` header under `headers_to_pass`, just as you would do with any other header.
+
+When doing this, **all your cookies** are sent to all backends inside the endpoint. Use this option wisely!
 
 Example:
 
-	{
-	  "version": 2,
-	  "endpoints": [
-	    {
-	      "endpoint": "/v1/foo",
-	      "method": "GET",
-	      "headers_to_pass": [
-        	"Cookie"
-      	  ],
-	      "backend": [
-	        {
-	          "url_pattern": "/catalog",
-	          "sd": "static",
-	          "host": [
-	            "http://some.api.com:9000"
-	          ]
-	        }
-	      ]
-	    }
-	  ]
-	}
+    {
+      "version": 2,
+      "endpoints": [
+        {
+          "endpoint": "/v1/foo",
+          "method": "GET",
+          "headers_to_pass": [
+            "Cookie"
+            ],
+          "backend": [
+            {
+              "url_pattern": "/catalog",
+              "sd": "static",
+              "host": [
+                "http://some.api.com:9000"
+              ]
+            }
+          ]
+        }
+      ]
+    }

--- a/endpoints/parameter-forwarding.md
+++ b/endpoints/parameter-forwarding.md
@@ -20,7 +20,7 @@ The **default policy** for data forwarding works as follows:
 
 You can change this behavior according to your needs, and define which elements are allowed to pass.
 
-However, if you want a specific endpoint to act just like a regular proxy without doing any operations use the `no-op` option on its encoding options. When using `no-op`, the gateway can't probe the content whatsoever. The request goes from the client to the backend "as is".
+However, if you want a specific endpoint to act just like a regular proxy without doing any operations use the `no-op` option on its encoding options. When using `no-op`, the gateway can't do anything with the content. The request goes from the client to the backend "as is".
 
 # Query string forwarding
 KrakenD **sends all query string parameters to the backend by default**. Meaning that if an endpoint `/foo` receives the query string `/foo?a=1&b=2` all its declared backends are going to receive `a` and `b`.

--- a/endpoints/sequential-proxy.md
+++ b/endpoints/sequential-proxy.md
@@ -1,5 +1,5 @@
 ---
-lastmod: 2018-11-11
+lastmod: 2018-11-27
 date: 2018-11-11
 toc: true
 linktitle: Sequential Proxy

--- a/overview/introduction.md
+++ b/overview/introduction.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /overview/introduction/
-lastmod: 2018-10-20
+lastmod: 2018-11-26
 date: 2016-10-25
 linktitle: Introduction
 menu:


### PR DESCRIPTION
Documentation is not clear enough.

Expanding the parameter forwarding document and adding how to test it.