### PR TITLE
Allow prometheus exporter namespace to be configurable.

### DIFF
--- a/logging-metrics-tracing/opencensus.md
+++ b/logging-metrics-tracing/opencensus.md
@@ -18,7 +18,8 @@ You will be interested in Opencensus when you want to see data in one of its sup
 		"github_com/devopsfaith/krakend-opencensus": {
 			"exporters": {
 				"prometheus": {
-				"port": 9091
+					"port": 9091
+					"namespace": "krakend"
 				}
 			}
 		}

--- a/logging-metrics-tracing/prometheus.md
+++ b/logging-metrics-tracing/prometheus.md
@@ -12,14 +12,17 @@ menu:
 ---
 [Prometheus](https://prometheus.io/) is an open-source systems monitoring and alerting toolkit.
 
-The Opencensus exporter allows you export data to Prometheus. Enabling it only requires you to specify the port on which Prometheus is running, and your Prometheus instance will start receiving the data.
+The Opencensus exporter allows you push data to Prometheus. Enabling it only requires you to include in the root level of your configuration the Opencensus middleware with the `prometheus` exporter. Specify the `port` on which Prometheus is running, the `namespace` (optional), and Prometheus will start receiving the data.
 
 	"github_com/devopsfaith/krakend-opencensus": {
       "exporters": {
         "prometheus": {
-          "port": 9091
+            "port": 9091
+            "namespace": "krakend"
         }
 	  }
 	}
+- `port` on which Prometheus is listening
+- `namespace` sets the domain the metric belongs to. "krakend" is the default value when no `namespace` is provided.
 
 See also the [additional settings](/docs/logging-metrics-tracing/opencensus/) of the Opencensus module that can be declared.

--- a/logging-metrics-tracing/prometheus.md
+++ b/logging-metrics-tracing/prometheus.md
@@ -23,6 +23,6 @@ The Opencensus exporter allows you push data to Prometheus. Enabling it only req
 	  }
 	}
 - `port` on which Prometheus is listening
-- `namespace` sets the domain the metric belongs to. "krakend" is the default value when no `namespace` is provided.
+- `namespace` sets the domain the metric belongs to. Optional field.
 
 See also the [additional settings](/docs/logging-metrics-tracing/opencensus/) of the Opencensus module that can be declared.


### PR DESCRIPTION
Update of the documentation based on @jrasell PR:
https://github.com/devopsfaith/krakend-opencensus/pull/24