### PR TITLE
fix json typo

### DIFF
--- a/logging-metrics-tracing/logging.md
+++ b/logging-metrics-tracing/logging.md
@@ -79,9 +79,6 @@ If you select the `custom` format, you'll be able to use the `custom_format` fie
 
 The pattern to use is the same as the [go-logging library](https://github.com/op/go-logging/blob/master/format.go#L156)
 
-
-
-
 ## Logstash
 If you want to log using the Logstash standard via stdout, you have to add the `krakend-logstash` integration in the
 root level of your `krakend.json`, inside the `extra_config` section. **The `gologging` needs to be enabled too**.
@@ -91,12 +88,12 @@ For instance:
     "extra_config": {
       "github_com/devopsfaith/krakend-logstash": {
         "enabled": true
-      }
+      },
       "github_com/devopsfaith/krakend-gologging": {
-          "level": "INFO",
-          "prefix": "[KRAKEND]",
-          "syslog": false,
-          "stdout": true,
-          "format": "logstash"
+        "level": "INFO",
+        "prefix": "[KRAKEND]",
+        "syslog": false,
+        "stdout": true,
+        "format": "logstash"
       }
     }


### PR DESCRIPTION
- fix missing comma in logstash config json example
- remove multiple unused whitespaces
- and also apply 2 space indentation