### PR TITLE
Serve the repository under HTTPS #91

### DIFF
--- a/overview/installing.md
+++ b/overview/installing.md
@@ -48,7 +48,7 @@ The installation process requires following these steps:
 
 Paste this in the terminal:
 {{< terminal title="Yum based" >}}
-rpm -Uvh http://repo.krakend.io/rpm/krakend-repo-0.2-0.x86_64.rpm
+rpm -Uvh {{< param download_repo >}}/rpm/krakend-repo-0.2-0.x86_64.rpm
 yum install -y krakend
 systemctl start krakend
 {{< /terminal >}}
@@ -56,7 +56,7 @@ systemctl start krakend
 ### Fedora
 Paste this in the terminal:
 {{< terminal title="DNF based" >}}
-rpm -Uvh http://repo.krakend.io/rpm/krakend-repo-0.2-0.x86_64.rpm
+rpm -Uvh {{< param download_repo >}}/rpm/krakend-repo-0.2-0.x86_64.rpm
 dnf install -y krakend
 systemctl start krakend
 {{< /terminal >}}
@@ -75,7 +75,7 @@ The installation process requires following these steps:
 Bottom line:
 {{< terminal title="DEB based" >}}
 apt-key adv --keyserver keyserver.ubuntu.com --recv {{< param pgp_key >}}
-echo "deb http://repo.krakend.io/apt stable main" | tee /etc/apt/sources.list.d/krakend.list
+echo "deb {{< param download_repo >}}/apt stable main" | tee /etc/apt/sources.list.d/krakend.list
 apt-get update
 apt-get install -y krakend
 {{< /terminal >}}

--- a/overview/verifying-packages.md
+++ b/overview/verifying-packages.md
@@ -7,7 +7,7 @@ notoc: true
 How to make sure what you are downloading is legit.
 
 ## PGP
-We will check the detached signature [PGP](http://repo.krakend.io/bin/krakend_{{< version >}}_amd64.tar.gz.asc) against our package [KrakenD](http://repo.krakend.io/bin/krakend_{{< version >}}_amd64.tar.gz).
+We will check the detached signature [PGP]({{< param download_repo >}}/bin/krakend_{{< version >}}_amd64.tar.gz.asc) against our package [KrakenD]({{< param download_repo >}}/bin/krakend_{{< version >}}_amd64.tar.gz).
 
     $ gpg --verify krakend_{{< version >}}_amd64.tar.gz.asc krakend_{{< version >}}_amd64.tar.gz
     gpg: Signature made Sun Mar 10 18:17:18 2019 UTC using RSA key ID {{< param pgp_key >}}
@@ -34,9 +34,9 @@ Now you can verify the signature of the package:
 
 ## SHA256
 
-To make sure the binary downloaded matches our SHA256 ensure the next 2 commands produce the same [SHA](http://repo.krakend.io/bin/krakend_{{< version >}}_amd64.tar.gz.sha256) output.
+To make sure the binary downloaded matches our SHA256 ensure the next 2 commands produce the same [SHA]({{< param download_repo >}}/bin/krakend_{{< version >}}_amd64.tar.gz.sha256) output.
 
     ## Your downloaded file
 	$ shasum -a 256 -b krakend_{{< version >}}_amd64.tar.gz
     ## Our SHA256
-    $ curl http://repo.krakend.io/bin/krakend_{{< version >}}_amd64.tar.gz.sha256
+    $ curl {{< param download_repo >}}/bin/krakend_{{< version >}}_amd64.tar.gz.sha256


### PR DESCRIPTION
repo.krakend.io is now served using https