### PR TITLE
Fix wrong JSON example syntax

### DIFF
--- a/endpoints/lua.md
+++ b/endpoints/lua.md
@@ -175,7 +175,7 @@ For the endpoint section:
 
     "extra_config": {
           "github.com/devopsfaith/krakend-lua/proxy": {
-            "pre": "print('Lua proxy!'); local r = request.load(); r:headers('X-from-lua', '1234');",
+            "pre": "print('Lua proxy!'); local r = request.load(); r:headers('X-from-lua', '1234');"
           }
     }
 
@@ -184,7 +184,7 @@ For the backend section:
 
     "extra_config": {
           "github.com/devopsfaith/krakend-lua/proxy/backend": {
-            "pre": "print('Showing body from backend-pre logic'); local r = request.load(); print(r:body('')); ",
+            "pre": "print('Showing body from backend-pre logic'); local r = request.load(); print(r:body(''));"
           }
     }
 


### PR DESCRIPTION
The JSON format does not allow commas at the end one field object.