### PR TITLE
Fixed tiny little typo in overview/guides

### DIFF
--- a/overview/guides.md
+++ b/overview/guides.md
@@ -8,7 +8,7 @@ title: Tutorials and Guides
 notoc: true
 weight: 1000
 ---
-The documentation in this site covers all the functionality of KrakenD API Gateway, but over time we have received from KrakenD users all kinds of tutorials, guides and other resources that illustrate how to to do a specific thing. We have included below a few links, but you can share yours.
+The documentation in this site covers all the functionality of KrakenD API Gateway, but over time we have received from KrakenD users all kinds of tutorials, guides and other resources that illustrate how to do a specific thing. We have included below a few links, but you can share yours.
 
 
 ## User-contributed resources

--- a/v1.3/overview/guides.md
+++ b/v1.3/overview/guides.md
@@ -9,7 +9,7 @@ title: Tutorials and Guides
 notoc: true
 weight: 1000
 ---
-The documentation in this site covers all the functionality of KrakenD API Gateway, but over time we have received from KrakenD users all kinds of tutorials, guides and other resources that illustrate how to to do a specific thing. We have included below a few links, but you can share yours.
+The documentation in this site covers all the functionality of KrakenD API Gateway, but over time we have received from KrakenD users all kinds of tutorials, guides and other resources that illustrate how to do a specific thing. We have included below a few links, but you can share yours.
 
 
 ## User-contributed resources


### PR DESCRIPTION
This commits fixed typo (`s/how to to do/how to do/g`) in overview/guides
page. And the reason why this commits updates "</a>" in
overview/guides.md is it doesn't have newline character("\n") at the end
of file (by editing it, its character was inserted automatically).