### PR TITLE
Fix bug in flexible_config.md

### DIFF
--- a/configuration/flexible-config.md
+++ b/configuration/flexible-config.md
@@ -253,6 +253,7 @@ Have a look at the highlighted lines:
                     }
                 }
             ]
+            }
             {{ end }}
         ]
     }


### PR DESCRIPTION
There was missing curly bracket "}" in krakend.json example.