### PR TITLE
Update common-expression-language-cel.md

### DIFF
--- a/endpoints/common-expression-language-cel.md
+++ b/endpoints/common-expression-language-cel.md
@@ -236,7 +236,7 @@ The following example is a bit more complex, as it **combines the sequential pro
                 },
                 {
                     "url_pattern": "/__debug/1?ignore={resp0_message}",
-                    "group": "sequence-1",
+                    "group": "sequence1",
                     "extra_config": {
                         "validation/cel": [
                             {
@@ -247,18 +247,18 @@ The following example is a bit more complex, as it **combines the sequential pro
                 },
                 {
                     "url_pattern": "/__debug/2",
-                    "group": "sequence-2",
+                    "group": "sequence2",
                     "extra_config": {
                         "validation/cel": [
                             {
-                                "check_expr": "resp_data.sequence-2.message == 'pong'"
+                                "check_expr": "resp_data.sequence2.message == 'pong'"
                             }
                         ]
                     }
                 },
                 {
                     "url_pattern": "/__debug/3",
-                    "group": "sequence-3",
+                    "group": "sequence3",
                     "extra_config": {
                         "validation/cel": [
                             {
@@ -269,7 +269,7 @@ The following example is a bit more complex, as it **combines the sequential pro
                 },
                 {
                     "url_pattern": "/__debug/4",
-                    "group": "sequence-4",
+                    "group": "sequence4",
                     "extra_config": {
                         "validation/cel": [
                             {


### PR DESCRIPTION
Using hyphen in variable names for CEL gives following error:

```
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/1?ignore={{.Resp0_message}}][CEL] 1 preEvaluator(s) loaded
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/1?ignore={{.Resp0_message}}][CEL] 0 postEvaluator(s) loaded
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/2] Building the backend pipe
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/2][CEL] Loading configuration
2022/04/12 10:59:07 KRAKEND DEBUG: [CEL] Parsing expression: resp_data.sequence-2.message == 'pong'
2022/04/12 10:59:07 KRAKEND DEBUG: [CEL] error parsing the expression ERROR: <input>:1:21: type 'primitive:INT64' does not support field selection
 | resp_data.sequence-2.message == 'pong'
 | ....................^
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/2][CEL] 0 preEvaluator(s) loaded
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/2][CEL] 0 postEvaluator(s) loaded
2022/04/12 10:59:07 KRAKEND DEBUG: [BACKEND: /__debug/3] Building the backend pipe
```